### PR TITLE
build(qicore): update url for qicore dependency

### DIFF
--- a/java/src/main/resources/application.yaml
+++ b/java/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ hapi:
     require_profile_for_validation: true
     implementationguides:
       qicore_4_1_1:
-        url: http://hl7.org/fhir/us/qicore/4.1.1/package.tgz
+        url: https://hl7.org/fhir/us/qicore/STU4.1.1/package.tgz
         name: hl7.fhir.us.qicore
         version: 4.1.1
       uscore_3_1_1:


### PR DESCRIPTION
This will be updated to a later version but in order to get the project to build and run locally, this is the MVP change needed.

The package URL is found on this page: 
https://hl7.org/fhir/us/qicore/STU4.1.1/downloads.html#package